### PR TITLE
Fix non-unity build with RGL gem

### DIFF
--- a/Code/Source/Entity/EntityManager.cpp
+++ b/Code/Source/Entity/EntityManager.cpp
@@ -14,6 +14,8 @@
  */
 
 #include <Entity/EntityManager.h>
+#include <Utilities/RGLUtils.h>
+#include <AzCore/Component/TransformBus.h>
 
 namespace RGL
 {

--- a/Code/Source/Entity/TerrainEntityManagerSystemComponent.cpp
+++ b/Code/Source/Entity/TerrainEntityManagerSystemComponent.cpp
@@ -14,6 +14,8 @@
  */
 #include <Entity/TerrainEntityManagerSystemComponent.h>
 #include <Utilities/RGLUtils.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace RGL
 {

--- a/Code/Source/Lidar/PipelineGraph.cpp
+++ b/Code/Source/Lidar/PipelineGraph.cpp
@@ -14,6 +14,8 @@
  */
 #include <Lidar/PipelineGraph.h>
 #include <Lidar/RaycastResults.h>
+#include <Utilities/RGLUtils.h>
+#include <rgl/api/extensions/ros2.h>
 
 namespace RGL
 {
@@ -224,7 +226,6 @@ namespace RGL
             return graph.IsPcPublishingEnabled();
         };
 
-
         // clang-format off
         AddConditionalNode(m_nodes.m_angularNoise, m_nodes.m_lidarTransform, m_nodes.m_rayTrace, NoiseCondition);
         AddConditionalNode(m_nodes.m_distanceNoise, m_nodes.m_rayTrace, m_nodes.m_rayTraceYield, NoiseCondition);
@@ -261,7 +262,8 @@ namespace RGL
         m_conditionalConnections.emplace_back(parent, child, condition, condition(*this));
     }
 
-    PipelineGraph::ConditionalConnection::ConditionalConnection(rgl_node_t parent, rgl_node_t child, const ConditionType& condition, bool activate)
+    PipelineGraph::ConditionalConnection::ConditionalConnection(
+        rgl_node_t parent, rgl_node_t child, const ConditionType& condition, bool activate)
         : m_parent(parent)
         , m_child(child)
         , m_condition(condition)

--- a/Code/Source/Lidar/PipelineGraph.h
+++ b/Code/Source/Lidar/PipelineGraph.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 
+#include <AzCore/Math/Matrix3x3.h>
 #include <ROS2/Communication/QoS.h>
 #include <rgl/api/core.h>
 
@@ -83,7 +84,7 @@ namespace RGL
         class ConditionalConnection
         {
         public:
-            ConditionalConnection(rgl_node_t parent, rgl_node_t child, const ConditionType& condition, bool activate=false);
+            ConditionalConnection(rgl_node_t parent, rgl_node_t child, const ConditionType& condition, bool activate = false);
             void Update(const PipelineGraph& graph);
 
         private:

--- a/Code/Source/Lidar/RaycastResults.h
+++ b/Code/Source/Lidar/RaycastResults.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <rgl/api/core.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/containers/unordered_map.h>
 
 namespace RGL
 {


### PR DESCRIPTION
The RGL gem is missing some header files,
here is what I needed to add to perform a successful non-unity build.