### PR TITLE
Copy RGL library to ouput directory

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 include(FindRGL.cmake)
-link_directories(/home/michalpelka/github/o3de-rgl-gem/Code/3rdParty/RobotecGPULidar/)
 ly_add_target(
     NAME RGL.Static STATIC
     NAMESPACE Gem

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 include(FindRGL.cmake)
-
+link_directories(/home/michalpelka/github/o3de-rgl-gem/Code/3rdParty/RobotecGPULidar/)
 ly_add_target(
     NAME RGL.Static STATIC
     NAMESPACE Gem
@@ -39,6 +39,13 @@ ly_add_target(
 )
 
 ly_target_link_libraries(RGL.Static PUBLIC ${RGL_SO_DIR})
+
+ly_add_target_files(
+        TARGETS
+        RGL.Static
+        FILES
+        ${RGL_SO_DIR}
+)
 
 ly_add_target(
     NAME RGL.API HEADERONLY


### PR DESCRIPTION
Used `ly_add_target_files` macro to copy RGL shared library.

According to documentation `ly_add_target_files` should copy given file next to target. On 2301.1 it resolves #18 . 
