### PR TITLE
Optimize scene updates to RGL

### DIFF
--- a/Code/Include/RGL/RGLBus.h
+++ b/Code/Include/RGL/RGLBus.h
@@ -33,6 +33,9 @@ namespace RGL
         virtual void SetSceneConfiguration(const SceneConfiguration& config) = 0;
         [[nodiscard]] virtual const SceneConfiguration& GetSceneConfiguration() const = 0;
 
+        //! Updates scene to the RGL
+        virtual void UpdateScene() = 0;
+
     protected:
         ~RGLRequests() = default;
     };

--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -32,12 +32,6 @@ namespace RGL
         EMotionFX::Integration::ActorComponentNotificationBus::Handler::BusConnect(entityId);
     }
 
-    ActorEntityManager::ActorEntityManager(ActorEntityManager&& other)
-        : EntityManager(std::move(other))
-    {
-        EMotionFX::Integration::ActorComponentNotificationBus::Handler::BusDisconnect();
-    }
-
     ActorEntityManager::~ActorEntityManager()
     {
         for (MeshPair mesh : m_meshes)

--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -106,11 +106,6 @@ namespace RGL
                     ActorEntity->GetId().ToString().c_str());
             }
         }
-
-        if (!m_entities.empty())
-        {
-            UpdatePose();
-        }
     }
 
     void ActorEntityManager::UpdateMeshVertices()

--- a/Code/Source/Entity/ActorEntityManager.h
+++ b/Code/Source/Entity/ActorEntityManager.h
@@ -32,8 +32,10 @@ namespace RGL
     {
     public:
         explicit ActorEntityManager(AZ::EntityId entityId);
-        ActorEntityManager(const ActorEntityManager& other) = default;
-        ActorEntityManager(ActorEntityManager&& other);
+        ActorEntityManager(const ActorEntityManager& other) = delete;
+        ActorEntityManager(ActorEntityManager&& other) = delete;
+        ActorEntityManager& operator=(ActorEntityManager&& rhs) = delete;
+        ActorEntityManager& operator=(const ActorEntityManager&) = delete;
         ~ActorEntityManager();
 
         void Update() override;

--- a/Code/Source/Entity/EntityManager.cpp
+++ b/Code/Source/Entity/EntityManager.cpp
@@ -24,13 +24,6 @@ namespace RGL
         AZ::EntityBus::Handler::BusConnect(m_entityId);
     }
 
-    EntityManager::EntityManager(EntityManager&& other)
-        : m_entityId{ other.m_entityId }
-        , m_entities{ AZStd::move(other.m_entities) }
-    {
-        AZ::EntityBus::Handler::BusConnect(m_entityId);
-    }
-
     EntityManager::~EntityManager()
     {
         AZ::EntityBus::Handler::BusDisconnect();

--- a/Code/Source/Entity/EntityManager.h
+++ b/Code/Source/Entity/EntityManager.h
@@ -27,9 +27,11 @@ namespace RGL
     class EntityManager : public AZ::EntityBus::Handler
     {
     public:
-        EntityManager(AZ::EntityId entityId);
-        EntityManager(const EntityManager& other) = default;
-        EntityManager(EntityManager&& other);
+        explicit EntityManager(AZ::EntityId entityId);
+        EntityManager(const EntityManager& other) = delete;
+        EntityManager(EntityManager&& other) = delete;
+        EntityManager& operator=(EntityManager&& rhs) = delete;
+        EntityManager& operator=(const EntityManager&) = delete;
         virtual ~EntityManager();
 
         virtual void Update();

--- a/Code/Source/Entity/MeshEntityManager.cpp
+++ b/Code/Source/Entity/MeshEntityManager.cpp
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <AzCore/Component/TransformBus.h>
+
 #include <Entity/MeshEntityManager.h>
 #include <Mesh/MeshLibraryBus.h>
 #include <Utilities/RGLUtils.h>
@@ -57,11 +57,6 @@ namespace RGL
             {
                 m_entities.emplace_back(entity);
             }
-        }
-
-        if (!m_entities.empty())
-        {
-            UpdatePose();
         }
     }
 } // namespace RGL

--- a/Code/Source/Entity/MeshEntityManager.cpp
+++ b/Code/Source/Entity/MeshEntityManager.cpp
@@ -25,12 +25,6 @@ namespace RGL
         AZ::Render::MeshComponentNotificationBus::Handler::BusConnect(entityId);
     }
 
-    MeshEntityManager::MeshEntityManager(MeshEntityManager&& other)
-        : EntityManager{ AZStd::move(other) }
-    {
-        AZ::Render::MeshComponentNotificationBus::Handler::BusConnect(m_entityId);
-    }
-
     MeshEntityManager::~MeshEntityManager()
     {
         AZ::Render::MeshComponentNotificationBus::Handler::BusDisconnect();

--- a/Code/Source/Entity/MeshEntityManager.h
+++ b/Code/Source/Entity/MeshEntityManager.h
@@ -25,9 +25,11 @@ namespace RGL
         , protected AZ::Render::MeshComponentNotificationBus::Handler
     {
     public:
-        MeshEntityManager(AZ::EntityId entityId);
-        MeshEntityManager(const MeshEntityManager& other) = default;
-        MeshEntityManager(MeshEntityManager&& other);
+        explicit MeshEntityManager(AZ::EntityId entityId);
+        MeshEntityManager(const MeshEntityManager& other) = delete;
+        MeshEntityManager(MeshEntityManager&& other) = delete;
+        MeshEntityManager& operator=(MeshEntityManager&& rhs) = delete;
+        MeshEntityManager& operator=(const MeshEntityManager&) = delete;
         ~MeshEntityManager() override;
 
     protected:

--- a/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Code/Source/Lidar/LidarRaycaster.cpp
@@ -118,6 +118,8 @@ namespace RGL
 
     ROS2::RaycastResult LidarRaycaster::PerformRaycast(const AZ::Transform& lidarTransform)
     {
+        RGLInterface::Get()->UpdateScene();
+
         const AZ::Matrix3x4 lidarPose = AZ::Matrix3x4::CreateFromTransform(lidarTransform);
 
         m_graph.ConfigureLidarTransformNode(lidarPose);

--- a/Code/Source/RGLSystemComponent.cpp
+++ b/Code/Source/RGLSystemComponent.cpp
@@ -160,7 +160,7 @@ namespace RGL
 
     void RGLSystemComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
     {
-        for (auto& [entityId, entityManager] : m_entityManagers)
+        for (auto&& [entityId, entityManager] : m_entityManagers)
         {
             entityManager->Update();
         }

--- a/Code/Source/RGLSystemComponent.cpp
+++ b/Code/Source/RGLSystemComponent.cpp
@@ -126,21 +126,21 @@ namespace RGL
             return;
         }
 
-        AZStd::shared_ptr<EntityManager> entityManager;
+        AZStd::unique_ptr<EntityManager> entityManager;
         if (entity.FindComponent<EMotionFX::Integration::ActorComponent>())
         {
-            entityManager = AZStd::make_shared<ActorEntityManager>(entity.GetId());
+            entityManager = AZStd::make_unique<ActorEntityManager>(entity.GetId());
         }
         else if (entity.FindComponent(AZ::Render::MeshComponentTypeId))
         {
-            entityManager = AZStd::make_shared<MeshEntityManager>(entity.GetId());
+            entityManager = AZStd::make_unique<MeshEntityManager>(entity.GetId());
         }
         else
         {
             return;
         }
 
-        [[maybe_unused]] bool inserted = m_entityManagers.emplace(entity.GetId(), entityManager).second;
+        [[maybe_unused]] bool inserted = m_entityManagers.emplace(entity.GetId(), AZStd::move(entityManager)).second;
         AZ_Error(__func__, inserted, "Object with provided entityId already exists.");
     }
 

--- a/Code/Source/RGLSystemComponent.h
+++ b/Code/Source/RGLSystemComponent.h
@@ -66,7 +66,7 @@ namespace RGL
         MeshLibrary m_meshLibrary;
         AZStd::set<AZ::EntityId> m_excludedEntities;
         SceneConfiguration m_sceneConfig;
-        AZStd::unordered_map<AZ::EntityId, AZStd::shared_ptr<EntityManager>> m_entityManagers;
+        AZStd::unordered_map<AZ::EntityId, AZStd::unique_ptr<EntityManager>> m_entityManagers;
         AZ::ScriptTimePoint m_sceneUpdateLastTime {};
     };
 } // namespace RGL

--- a/Code/Source/RGLSystemComponent.h
+++ b/Code/Source/RGLSystemComponent.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
-#include <AzCore/Component/TickBus.h>
+#include <AzCore/Script/ScriptTimePoint.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzFramework/Entity/EntityContextBus.h>
 #include <Lidar/LidarSystem.h>
@@ -30,8 +30,6 @@ namespace RGL
         : public AZ::Component
         , protected RGLRequestBus::Handler
         , protected AzFramework::EntityContextEventBus::Handler
-        , protected AZ::TickBus::Handler
-
     {
     public:
         AZ_COMPONENT(RGL::RGLSystemComponent, "{dbd5b1c5-249f-4eca-a142-2533ebe7f680}");
@@ -55,14 +53,12 @@ namespace RGL
         void ExcludeEntity(const AZ::EntityId& excludedEntityId) override;
         void SetSceneConfiguration(const SceneConfiguration& config) override;
         [[nodiscard]] const SceneConfiguration& GetSceneConfiguration() const override;
+        void UpdateScene() override;
 
         // AzFramework::EntityContextEventBus overrides
         void OnEntityContextCreateEntity(AZ::Entity& entity) override;
         void OnEntityContextDestroyEntity(const AZ::EntityId& id) override;
         void OnEntityContextReset() override;
-
-        // AZ::TickBus overrides
-        void OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time) override;
 
     private:
         LidarSystem m_rglLidarSystem;
@@ -71,5 +67,6 @@ namespace RGL
         AZStd::set<AZ::EntityId> m_excludedEntities;
         SceneConfiguration m_sceneConfig;
         AZStd::unordered_map<AZ::EntityId, AZStd::shared_ptr<EntityManager>> m_entityManagers;
+        AZ::ScriptTimePoint m_sceneUpdateLastTime {};
     };
 } // namespace RGL


### PR DESCRIPTION
This PR optimizes scene updates to RGL by:
- using `TransformChangedEvent` to determine whether to update the pose of the entity
- triggering scene updates (entities pose & skinning) on raytracing request

I have tested these changes on the scene with three LiDARs and multiple Actor entities (80). FPS increased by ~4,5 times.

| Before | After |
|--:|--:|
| [o3de-rgl-skinned-stress.webm](https://github.com/RobotecAI/o3de-rgl-gem/assets/112629916/36e6cca3-9bd4-4ab9-9057-b080b1cd3cf6) | [o3de-rgl-skinned-stress-optimized.webm](https://github.com/RobotecAI/o3de-rgl-gem/assets/112629916/24109aec-e2f8-4397-af30-1dfb705605a2) |
