### PR TITLE
Ensure the entity's pose will be updated after creating it

### DIFF
--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -100,6 +100,8 @@ namespace RGL
                     ActorEntity->GetId().ToString().c_str());
             }
         }
+
+        m_isPoseUpdateNeeded = true;
     }
 
     void ActorEntityManager::UpdateMeshVertices()

--- a/Code/Source/Entity/EntityManager.h
+++ b/Code/Source/Entity/EntityManager.h
@@ -47,6 +47,7 @@ namespace RGL
 
         AZ::EntityId m_entityId;
         AZStd::vector<rgl_entity_t> m_entities;
+        bool m_isPoseUpdateNeeded{ false };
     private:
 
         AZ::TransformChangedEvent::Handler m_transformChangedHandler{[this](
@@ -63,7 +64,6 @@ namespace RGL
                 m_isPoseUpdateNeeded = true;
             }};
 
-        bool m_isPoseUpdateNeeded{ false };
         AZ::Transform m_worldTm{ AZ::Transform::CreateIdentity() };
         AZStd::optional<AZ::Vector3> m_nonUniformScale{ AZStd::nullopt };
     };

--- a/Code/Source/Entity/MeshEntityManager.cpp
+++ b/Code/Source/Entity/MeshEntityManager.cpp
@@ -52,5 +52,7 @@ namespace RGL
                 m_entities.emplace_back(entity);
             }
         }
+
+        m_isPoseUpdateNeeded = true;
     }
 } // namespace RGL


### PR DESCRIPTION
Before this PR, if the static entity's model was loaded after raycast, its pose was never updated. The flag setting has been added to update the position after the model is loaded.