### PR TITLE
Fix terrain data management

### DIFF
--- a/Code/Source/Entity/Terrain/TerrainData.cpp
+++ b/Code/Source/Entity/Terrain/TerrainData.cpp
@@ -12,22 +12,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Entity/Terrain/TerrainData.h>
-
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
+#include <Utilities/RGLUtils.h>
+#include <Entity/Terrain/TerrainData.h>
 
 namespace RGL
 {
-    bool TerrainData::UpdateBounds(AZ::Aabb newWorldBounds)
+    bool TerrainData::UpdateBounds(const AZ::Aabb& newWorldBounds)
     {
         if (newWorldBounds == m_currentWorldBounds)
         {
             // This is only for world bound creation, not for update.
             return false;
         }
-
-        m_currentWorldBounds = newWorldBounds;
 
         size_t heightfieldGridColumns{}, heighfieldGridRows{};
         Physics::HeightfieldProviderRequestsBus::BroadcastResult(
@@ -39,6 +37,8 @@ namespace RGL
         {
             return false;
         }
+
+        m_currentWorldBounds = newWorldBounds;
 
         AZ::Vector2 heightfieldGridSpacing{};
         Physics::HeightfieldProviderRequestsBus::BroadcastResult(
@@ -123,5 +123,15 @@ namespace RGL
         m_currentWorldBounds = AZ::Aabb::CreateFromPoint(AZ::Vector3::CreateZero());
         m_vertices.clear();
         m_indices.clear();
+    }
+
+    const AZStd::vector<rgl_vec3f>& TerrainData::GetVertices() const
+    {
+        return m_vertices;
+    }
+
+    const AZStd::vector<rgl_vec3i>& TerrainData::GetIndices() const
+    {
+        return m_indices;
     }
 } // namespace RGL

--- a/Code/Source/Entity/Terrain/TerrainData.h
+++ b/Code/Source/Entity/Terrain/TerrainData.h
@@ -1,0 +1,39 @@
+/* Copyright 2020-2021, Robotec.ai sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <rgl/api/core.h>
+
+#include <AzCore/Math/Aabb.h>
+
+namespace RGL
+{
+    struct TerrainData
+    {
+        AZ::Aabb m_currentWorldBounds = { AZ::Aabb::CreateFromPoint(AZ::Vector3::CreateZero()) };
+        AZStd::vector<rgl_vec3f> m_vertices;
+        AZStd::vector<rgl_vec3i> m_indices;
+
+        //! Returns whether or not newWorldBounds resulted in terrain update.
+        bool UpdateBounds(AZ::Aabb newWorldBounds);
+        void UpdateDirtyRegion(const AZ::Aabb& dirtyRegion);
+
+        void Clear();
+
+    private:
+        static constexpr size_t TrianglesPerSector = 2LU;
+    };
+
+} // namespace RGL

--- a/Code/Source/Entity/Terrain/TerrainData.h
+++ b/Code/Source/Entity/Terrain/TerrainData.h
@@ -14,26 +14,29 @@
  */
 #pragma once
 
-#include <rgl/api/core.h>
-
 #include <AzCore/Math/Aabb.h>
+#include <rgl/api/core.h>
 
 namespace RGL
 {
-    struct TerrainData
+    class TerrainData
     {
-        AZ::Aabb m_currentWorldBounds = { AZ::Aabb::CreateFromPoint(AZ::Vector3::CreateZero()) };
-        AZStd::vector<rgl_vec3f> m_vertices;
-        AZStd::vector<rgl_vec3i> m_indices;
-
+    public:
         //! Returns whether or not newWorldBounds resulted in terrain update.
-        bool UpdateBounds(AZ::Aabb newWorldBounds);
+        bool UpdateBounds(const AZ::Aabb& newWorldBounds);
         void UpdateDirtyRegion(const AZ::Aabb& dirtyRegion);
 
         void Clear();
 
+        [[nodiscard]] const AZStd::vector<rgl_vec3f>& GetVertices() const;
+        [[nodiscard]] const AZStd::vector<rgl_vec3i>& GetIndices() const;
+
     private:
         static constexpr size_t TrianglesPerSector = 2LU;
+
+        AZ::Aabb m_currentWorldBounds = { AZ::Aabb::CreateFromPoint(AZ::Vector3::CreateZero()) };
+        AZStd::vector<rgl_vec3f> m_vertices;
+        AZStd::vector<rgl_vec3i> m_indices;
     };
 
 } // namespace RGL

--- a/Code/Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.cpp
+++ b/Code/Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.cpp
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 #include <AzCore/Serialization/SerializeContext.h>
-#include <Entity/TerrainEntityManagerEditorSystemComponent.h>
+#include <Entity/Terrain/TerrainEntityManagerEditorSystemComponent.h>
 
 namespace RGL
 {
@@ -41,12 +41,6 @@ namespace RGL
         [[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         BaseSystemComponent::GetRequiredServices(required);
-    }
-
-    void TerrainEntityManagerEditorSystemComponent::GetDependentServices(
-        [[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
-    {
-        BaseSystemComponent::GetDependentServices(dependent);
     }
 
     void TerrainEntityManagerEditorSystemComponent::Activate()

--- a/Code/Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.h
+++ b/Code/Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.h
@@ -14,7 +14,7 @@
  */
 #pragma once
 
-#include <Entity/TerrainEntityManagerSystemComponent.h>
+#include <Entity/Terrain/TerrainEntityManagerSystemComponent.h>
 
 namespace RGL
 {
@@ -30,10 +30,9 @@ namespace RGL
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
         TerrainEntityManagerEditorSystemComponent() = default;
-        ~TerrainEntityManagerEditorSystemComponent() = default;
+        ~TerrainEntityManagerEditorSystemComponent() override = default;
 
     private:
         void Activate() override;

--- a/Code/Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.h
+++ b/Code/Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.h
@@ -32,7 +32,7 @@ namespace RGL
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
         TerrainEntityManagerEditorSystemComponent() = default;
-        ~TerrainEntityManagerEditorSystemComponent() override = default;
+        ~TerrainEntityManagerEditorSystemComponent() = default;
 
     private:
         void Activate() override;

--- a/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.cpp
+++ b/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.cpp
@@ -103,12 +103,9 @@ namespace RGL
 
         EnsureRGLEntityDestroyed();
 
-        Utils::SafeRglMeshCreate(
-            m_rglMesh,
-            m_terrainData.m_vertices.data(),
-            m_terrainData.m_vertices.size(),
-            m_terrainData.m_indices.data(),
-            m_terrainData.m_indices.size());
+        const auto& vertices = m_terrainData.GetVertices();
+        const auto& indices = m_terrainData.GetIndices();
+        Utils::SafeRglMeshCreate(m_rglMesh, vertices.data(), vertices.size(), indices.data(), indices.size());
 
         if (!m_rglMesh)
         {
@@ -128,15 +125,15 @@ namespace RGL
 
     void TerrainEntityManagerSystemComponent::UpdateDirtyRegion(const AZ::Aabb& dirtyRegion)
     {
-        if (m_terrainData.m_vertices.empty())
+        const auto& vertices = m_terrainData.GetVertices();
+        if (vertices.empty())
         {
             // Dirty regions can only be updated after data creation and before destruction. (See TerrainDataRequests).
             return;
         }
 
         m_terrainData.UpdateDirtyRegion(dirtyRegion);
-        RGL_CHECK(
-            rgl_mesh_update_vertices(m_rglMesh, m_terrainData.m_vertices.data(), aznumeric_cast<int32_t>(m_terrainData.m_vertices.size())));
+        RGL_CHECK(rgl_mesh_update_vertices(m_rglMesh, vertices.data(), aznumeric_cast<int32_t>(vertices.size())));
     }
 
     void TerrainEntityManagerSystemComponent::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)

--- a/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.cpp
+++ b/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.cpp
@@ -1,0 +1,154 @@
+/* Copyright 2020-2021, Robotec.ai sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <Entity/Terrain/TerrainEntityManagerSystemComponent.h>
+#include <Utilities/RGLUtils.h>
+
+namespace RGL
+{
+    void TerrainEntityManagerSystemComponent::OnTerrainDataCreateEnd()
+    {
+        UpdateWorldBounds();
+    }
+
+    void TerrainEntityManagerSystemComponent::OnTerrainDataDestroyEnd()
+    {
+        m_terrainData.Clear();
+        EnsureRGLEntityDestroyed();
+    }
+
+    void TerrainEntityManagerSystemComponent::Activate()
+    {
+        AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusConnect();
+    }
+
+    void TerrainEntityManagerSystemComponent::Deactivate()
+    {
+        AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusDisconnect();
+        m_terrainData.Clear();
+        EnsureRGLEntityDestroyed();
+    }
+
+    void TerrainEntityManagerSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<TerrainEntityManagerSystemComponent, AZ::Component>()->Version(0);
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<TerrainEntityManagerSystemComponent>("Terrain Entity Manager", "Manages the RGL Terrain entity.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "RGL")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
+            }
+        }
+    }
+
+    void TerrainEntityManagerSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("TerrainEntityManagerService"));
+    }
+
+    void TerrainEntityManagerSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("TerrainEntityManagerService"));
+    }
+
+    void TerrainEntityManagerSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("RGLService"));
+    }
+
+    void TerrainEntityManagerSystemComponent::EnsureRGLEntityDestroyed()
+    {
+        if (m_rglEntity)
+        {
+            RGL_CHECK(rgl_entity_destroy(m_rglEntity));
+            m_rglEntity = nullptr;
+        }
+
+        if (m_rglMesh)
+        {
+            RGL_CHECK(rgl_mesh_destroy(m_rglMesh));
+            m_rglMesh = nullptr;
+        }
+    }
+
+    void TerrainEntityManagerSystemComponent::UpdateWorldBounds()
+    {
+        AZ::Aabb newWorldBounds = AZ::Aabb::CreateFromPoint(AZ::Vector3::CreateZero());
+        AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
+            newWorldBounds, &AzFramework::Terrain::TerrainDataRequests::GetTerrainAabb);
+
+        if (!m_terrainData.UpdateBounds(newWorldBounds))
+        {
+            // The terrain data was not updated. No need to update the RGL mesh.
+            return;
+        }
+
+        EnsureRGLEntityDestroyed();
+
+        Utils::SafeRglMeshCreate(
+            m_rglMesh,
+            m_terrainData.m_vertices.data(),
+            m_terrainData.m_vertices.size(),
+            m_terrainData.m_indices.data(),
+            m_terrainData.m_indices.size());
+
+        if (!m_rglMesh)
+        {
+            AZ_Assert(false, "The TerrainEntityManager was unable to create an RGL mesh.");
+            return;
+        }
+
+        Utils::SafeRglEntityCreate(m_rglEntity, m_rglMesh);
+        if (!m_rglEntity)
+        {
+            AZ_Assert(false, "The TerrainEntityManager was unable to create an RGL entity.");
+            return;
+        }
+
+        RGL_CHECK(rgl_entity_set_pose(m_rglEntity, &Utils::IdentityTransform));
+    }
+
+    void TerrainEntityManagerSystemComponent::UpdateDirtyRegion(const AZ::Aabb& dirtyRegion)
+    {
+        if (m_terrainData.m_vertices.empty())
+        {
+            // Dirty regions can only be updated after data creation and before destruction. (See TerrainDataRequests).
+            return;
+        }
+
+        m_terrainData.UpdateDirtyRegion(dirtyRegion);
+        RGL_CHECK(
+            rgl_mesh_update_vertices(m_rglMesh, m_terrainData.m_vertices.data(), aznumeric_cast<int32_t>(m_terrainData.m_vertices.size())));
+    }
+
+    void TerrainEntityManagerSystemComponent::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
+    {
+        if ((dataChangedMask & TerrainDataChangedMask::Settings) != TerrainDataChangedMask::None)
+        {
+            UpdateWorldBounds();
+        }
+
+        if ((dataChangedMask & TerrainDataChangedMask::HeightData) != TerrainDataChangedMask::None)
+        {
+            UpdateDirtyRegion(dirtyRegion);
+        }
+    }
+} // namespace RGL

--- a/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.h
+++ b/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.h
@@ -14,10 +14,13 @@
  */
 #pragma once
 
+#include <rgl/api/core.h>
+
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzFramework/Visibility/BoundsBus.h>
-#include <rgl/api/core.h>
+
+#include <Entity/Terrain/TerrainData.h>
 
 namespace RGL
 {
@@ -35,21 +38,20 @@ namespace RGL
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
         TerrainEntityManagerSystemComponent() = default;
-        ~TerrainEntityManagerSystemComponent();
 
         // AzFramework::Terrain::TerrainDataNotificationBus overrides
+        void OnTerrainDataCreateEnd() override;
+        void OnTerrainDataDestroyEnd() override;
         void OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask) override;
 
     protected:
-        void Init() override;
         void Activate() override;
         void Deactivate() override;
 
     private:
-        void EnsureManagedEntityDestroyed();
+        void EnsureRGLEntityDestroyed();
 
         void UpdateWorldBounds();
         void UpdateDirtyRegion(const AZ::Aabb& dirtyRegion);
@@ -57,10 +59,6 @@ namespace RGL
         rgl_mesh_t m_rglMesh{ nullptr };
         rgl_entity_t m_rglEntity{ nullptr };
 
-        AZ::Aabb m_currentWorldBounds = AZ::Aabb::CreateFromPoint(AZ::Vector3::CreateZero());
-        AZStd::vector<rgl_vec3f> m_vertices;
-        AZStd::vector<rgl_vec3i> m_indices;
-
-        static constexpr size_t TrianglesPerSector = 2LU;
+        TerrainData m_terrainData;
     };
 } // namespace RGL

--- a/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.h
+++ b/Code/Source/Entity/Terrain/TerrainEntityManagerSystemComponent.h
@@ -14,13 +14,11 @@
  */
 #pragma once
 
-#include <rgl/api/core.h>
-
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzFramework/Visibility/BoundsBus.h>
-
 #include <Entity/Terrain/TerrainData.h>
+#include <rgl/api/core.h>
 
 namespace RGL
 {

--- a/Code/Source/RGLEditorModule.cpp
+++ b/Code/Source/RGLEditorModule.cpp
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <Entity/TerrainEntityManagerEditorSystemComponent.h>
+#include <Entity/Terrain/TerrainEntityManagerEditorSystemComponent.h>
 #include <RGLEditorSystemComponent.h>
 #include <RGLModuleInterface.h>
 #include <SceneConfigurationComponent.h>

--- a/Code/Source/RGLModuleInterface.h
+++ b/Code/Source/RGLModuleInterface.h
@@ -16,7 +16,7 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
-#include <Entity/TerrainEntityManagerSystemComponent.h>
+#include <Entity/Terrain/TerrainEntityManagerSystemComponent.h>
 #include <RGLSystemComponent.h>
 
 namespace RGL

--- a/Code/rgl_editor_files.cmake
+++ b/Code/rgl_editor_files.cmake
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 set(FILES
-        Source/Entity/TerrainEntityManagerEditorSystemComponent.cpp
-        Source/Entity/TerrainEntityManagerEditorSystemComponent.h
+        Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.cpp
+        Source/Entity/Terrain/TerrainEntityManagerEditorSystemComponent.h
         Source/RGLEditorSystemComponent.cpp
         Source/RGLEditorSystemComponent.h
 )

--- a/Code/rgl_files.cmake
+++ b/Code/rgl_files.cmake
@@ -18,8 +18,10 @@ set(FILES
         Source/Entity/MeshEntityManager.h
         Source/Entity/EntityManager.cpp
         Source/Entity/EntityManager.h
-        Source/Entity/TerrainEntityManagerSystemComponent.cpp
-        Source/Entity/TerrainEntityManagerSystemComponent.h
+        Source/Entity/Terrain/TerrainData.cpp
+        Source/Entity/Terrain/TerrainData.h
+        Source/Entity/Terrain/TerrainEntityManagerSystemComponent.cpp
+        Source/Entity/Terrain/TerrainEntityManagerSystemComponent.h
         Source/Lidar/LidarRaycaster.cpp
         Source/Lidar/LidarRaycaster.h
         Source/Lidar/LidarSystem.cpp


### PR DESCRIPTION
This pr aims to fix:
  - #29
  - #25,

It introduces the following changes:
  - Terrain data management is now in-line with the `TerrainDataRequestBus`,
  - Terrain-related files were moved to the `Terrain` subdirectory,
  - Small clean-up.