### PR TITLE
Fix terrain mesh alignment issues

### DIFF
--- a/Code/Source/Entity/Terrain/TerrainData.cpp
+++ b/Code/Source/Entity/Terrain/TerrainData.cpp
@@ -54,13 +54,15 @@ namespace RGL
         m_vertices.reserve(vertexCount);
 
         const AZ::Vector3 worldMin = newWorldBounds.GetMin();
+        const AZ::Vector2 constrictedAlignedStartPoint = (AZ::Vector2(worldMin) / heightfieldGridSpacing).GetCeil() * heightfieldGridSpacing;
+
         for (size_t vertexIndexX = 0LU; vertexIndexX < m_gridColumns; ++vertexIndexX)
         {
             for (size_t vertexIndexY = 0LU; vertexIndexY < m_gridRows; ++vertexIndexY)
             {
                 m_vertices.emplace_back(rgl_vec3f{
-                    worldMin.GetX() + aznumeric_cast<float>(vertexIndexX) * heightfieldGridSpacing.GetX(),
-                    worldMin.GetY() + aznumeric_cast<float>(vertexIndexY) * heightfieldGridSpacing.GetY(),
+                    constrictedAlignedStartPoint.GetX() + aznumeric_cast<float>(vertexIndexX) * heightfieldGridSpacing.GetX(),
+                    constrictedAlignedStartPoint.GetY() + aznumeric_cast<float>(vertexIndexY) * heightfieldGridSpacing.GetY(),
                     0.0f,
                 });
             }


### PR DESCRIPTION
This pr aims to fix #35.

Before the fix (for terrain of size 5x2). First picture - Scene queries, second - RGL.
![SQ-before](https://github.com/user-attachments/assets/cbfc3f3e-6f77-4912-a639-81c4509e408e)

![RGL-before](https://github.com/user-attachments/assets/ca09ac9b-c599-43df-ad99-5a5aea5c35e8)

The minimal point of the mesh had to be adjusted as it is in the `TerrainPhysicsColliderComponent`:
![code](https://github.com/user-attachments/assets/5006de98-dfbb-4751-bb5e-fdb57189fc87)

After the fix (for terrain of size 5x5). First picture - Scene queries, second - RGL.
![SQ-after](https://github.com/user-attachments/assets/63d91750-2e98-4bc4-a235-b218081e5537)

![RGL-after](https://github.com/user-attachments/assets/e9537f68-4a8b-40b5-a7e1-23b3b4c99286)

**_Note:_** _Upon further examination, the physics collider does not cover the same area as the rendered terrain mesh. This fix ensures only that the terrain mesh generated by the RGL gem aligns with the heightfield collider of the terrain, not the rendered geometry._