### PR TITLE
Require ROS 2 Gem 3.2.0

### DIFF
--- a/gem.json
+++ b/gem.json
@@ -18,7 +18,7 @@
     "requirements": "Requires a CUDA-capable GPU with the nvidia drivers specified in the README.md file of the RGL gem github repository.",
     "documentation_url": "",
     "dependencies": [
-        "ROS2"
+        "ROS2>=3.2.0"
     ],
     "restricted": "RGL"
 }


### PR DESCRIPTION
`ROS2::RayRange` structure was only added very recently in https://github.com/o3de/o3de-extras/pull/744

Using older o3de-extras cause the following compile error:
```
[build] /home/jhanca/devroot/o3de-rgl-gem/Code/Source/Lidar/LidarRaycaster.h:35:38: error: no type named 'RayRange' in namespace 'ROS2'
[build]         void ConfigureRayRange(ROS2::RayRange range) override;
[build]                                ~~~~~~^
[build] /home/jhanca/devroot/o3de-rgl-gem/Code/Source/Lidar/LidarRaycaster.h:62:31: error: no member named 'RayRange' in namespace 'ROS2'
[build]         AZStd::optional<ROS2::RayRange> m_range{};
```

It makes sense to enforce the version of `ROS 2` Gem within `gem.json` file, which would result in the following:

```
[build]   [ERROR] o3de.cmake: Failed to resolve dependencies:
[build] 
[build]     The following dependency requirements could not be satisfied:
[build] 
[build]   The project requires ROS2==2.0.0
[build] 
[build]   <Gem ROS2ScriptIntegration==1.0.0> requires ROS2
[build] 
[build]   <Gem RGL==0.0.0> requires ROS2>=3.2.0
```