### PR TITLE
Allow for the gem to be built with ROS2 stabilization version

### DIFF
--- a/gem.json
+++ b/gem.json
@@ -22,7 +22,7 @@
     "requirements": "Requires a CUDA-capable GPU with the nvidia drivers specified in the README.md file of the RGL gem github repository.",
     "documentation_url": "",
     "dependencies": [
-        "ROS2==2.0.0"
+        "ROS2<=3.1.0"
     ],
     "restricted": "RGL"
 }


### PR DESCRIPTION
As requested by @jhanca-robotecai in https://github.com/RobotecAI/o3de-rgl-gem/issues/47 this pr allows the gem to be built with newer ROS2 gem versions (up to the breaking changes).