### PR TITLE
Fix event responsiveness

### DIFF
--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -37,7 +37,7 @@ namespace RGL
 
     void ActorEntityManager::Update()
     {
-        if (RGLInterface::Get()->GetSceneConfiguration().m_isSkinnedMeshUpdateEnabled)
+        if (!m_entities.empty() && RGLInterface::Get()->GetSceneConfiguration().m_isSkinnedMeshUpdateEnabled)
         {
             UpdateMeshVertices();
         }
@@ -97,6 +97,11 @@ namespace RGL
         }
 
         m_isPoseUpdateNeeded = true;
+    }
+
+    void ActorEntityManager::OnActorInstanceDestroyed(EMotionFX::ActorInstance* actorInstance)
+    {
+        m_entities.clear();
     }
 
     void ActorEntityManager::UpdateMeshVertices()

--- a/Code/Source/Entity/ActorEntityManager.h
+++ b/Code/Source/Entity/ActorEntityManager.h
@@ -45,6 +45,7 @@ namespace RGL
     protected:
         // ActorComponentNotificationBus overrides
         void OnActorInstanceCreated(EMotionFX::ActorInstance* actorInstance) override;
+        void OnActorInstanceDestroyed(EMotionFX::ActorInstance* actorInstance) override;
 
     private:
         EMotionFX::ActorInstance* m_actorInstance = nullptr;

--- a/Code/Source/Entity/MeshEntityManager.cpp
+++ b/Code/Source/Entity/MeshEntityManager.cpp
@@ -102,9 +102,4 @@ namespace RGL
             }
         }
     }
-
-    void MeshEntityManager::OnMaterialPropertiesUpdated([[maybe_unused]] const AZ::Render::MaterialAssignmentMap& materials)
-    {
-        AZ_Printf(__func__, "Material properties updated");
-    }
 } // namespace RGL

--- a/Code/Source/Entity/MeshEntityManager.cpp
+++ b/Code/Source/Entity/MeshEntityManager.cpp
@@ -80,6 +80,11 @@ namespace RGL
         AZ::Render::MaterialComponentNotificationBus::Handler::BusConnect(m_entityId);
     }
 
+    void MeshEntityManager::OnModelPreDestroy()
+    {
+        m_entities.clear();
+    }
+
     void MeshEntityManager::OnMaterialsUpdated(const AZ::Render::MaterialAssignmentMap& materials)
     {
         if (m_entities.empty())

--- a/Code/Source/Entity/MeshEntityManager.cpp
+++ b/Code/Source/Entity/MeshEntityManager.cpp
@@ -102,4 +102,9 @@ namespace RGL
             }
         }
     }
+
+    void MeshEntityManager::OnMaterialPropertiesUpdated([[maybe_unused]] const AZ::Render::MaterialAssignmentMap& materials)
+    {
+        AZ_Printf(__func__, "Material properties updated");
+    }
 } // namespace RGL

--- a/Code/Source/Entity/MeshEntityManager.h
+++ b/Code/Source/Entity/MeshEntityManager.h
@@ -43,6 +43,7 @@ namespace RGL
         void OnModelReady(
             const AZ::Data::Asset<AZ::RPI::ModelAsset>& modelAsset,
             [[maybe_unused]] const AZ::Data::Instance<AZ::RPI::Model>& model) override;
+        void OnModelPreDestroy() override;
 
         // AZ::Render::MaterialComponentNotificationBus implementation overrides
         void OnMaterialsUpdated(const AZ::Render::MaterialAssignmentMap& materials) override;

--- a/Code/Source/Entity/MeshEntityManager.h
+++ b/Code/Source/Entity/MeshEntityManager.h
@@ -47,6 +47,7 @@ namespace RGL
 
         // AZ::Render::MaterialComponentNotificationBus implementation overrides
         void OnMaterialsUpdated(const AZ::Render::MaterialAssignmentMap& materials) override;
+        void OnMaterialPropertiesUpdated([[maybe_unused]] const AZ::Render::MaterialAssignmentMap& materials) override;
 
         AZStd::unordered_map<AZ::RPI::ModelMaterialSlot::StableId, size_t> m_materialSlotMeshIdMap;
     };

--- a/Code/Source/Entity/MeshEntityManager.h
+++ b/Code/Source/Entity/MeshEntityManager.h
@@ -47,7 +47,6 @@ namespace RGL
 
         // AZ::Render::MaterialComponentNotificationBus implementation overrides
         void OnMaterialsUpdated(const AZ::Render::MaterialAssignmentMap& materials) override;
-        void OnMaterialPropertiesUpdated([[maybe_unused]] const AZ::Render::MaterialAssignmentMap& materials) override;
 
         AZStd::unordered_map<AZ::RPI::ModelMaterialSlot::StableId, size_t> m_materialSlotMeshIdMap;
     };


### PR DESCRIPTION
This pr aims to improve gem's responsiveness to various events related to managed entities.

Those events include:
- Mesh component model changes (see #23)
- Actor instance destruction handling