### PR TITLE
Support ROS 2 Jazzy (main backport)

### DIFF
--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -98,7 +98,8 @@ if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
 else ()
     message(WARNING "Omitting the RobotecGPULidar library download. This is intended when using the Clion multi-profile"
             " project reload. This may also happen due to interruption of previous project configurations. If you have"
-            " any issues related to the libRobotecGPULidar.so file please clear cmake cache before next build attempt."
+            " any issues related to the libRobotecGPULidar.so file please clear cmake cache for this gem"
+            " ({build_dir}/External/o3de-rgl-gem-*) before next build attempt."
     )
 endif ()
 

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -16,13 +16,13 @@ set(RGL_VERSION 0.15.0)
 set(RGL_TAG v${RGL_VERSION})
 
 # Determine RGL binary to download based on ROS distro
-if($ENV{ROS_DISTRO} STREQUAL "humble")
+if ($ENV{ROS_DISTRO} STREQUAL "humble")
     set(RGL_LINUX_ZIP_FILENAME_BASE Linux-x64)
-elseif($ENV{ROS_DISTRO} STREQUAL "jazzy")
+elseif ($ENV{ROS_DISTRO} STREQUAL "jazzy")
     set(RGL_LINUX_ZIP_FILENAME_BASE Linux-x64-jazzy)
-else()
+else ()
     message(FATAL_ERROR "ROS not found or ROS distro not supported. Please use one of {humble, jazzy}.")
-endif()
+endif ()
 set(RGL_LINUX_ZIP_FILENAME ${RGL_LINUX_ZIP_FILENAME_BASE}.zip)
 
 set(RGL_LINUX_ZIP_URL https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_LINUX_ZIP_FILENAME})
@@ -50,15 +50,15 @@ if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
     if (NOT EXISTS ${DEST_SO_DIR}/${SO_FILENAME})
         # Download the RGL archive files
         file(DOWNLOAD
-            ${RGL_LINUX_ZIP_URL}
-            ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
+                ${RGL_LINUX_ZIP_URL}
+                ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
         )
 
         # Extract the contents of the downloaded archive files
         file(ARCHIVE_EXTRACT INPUT ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
-            DESTINATION ${DEST_SO_DIR}
-            PATTERNS ${SO_REL_PATH}
-            VERBOSE
+                DESTINATION ${DEST_SO_DIR}
+                PATTERNS ${SO_REL_PATH}
+                VERBOSE
         )
 
         # Move the extracted files to their desired locations
@@ -71,12 +71,12 @@ if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
     # Download API headers if not exist
     if (NOT EXISTS ${DEST_API_DIR}/core.h OR NOT EXISTS ${DEST_API_DIR}/extensions/ros2.h)
         file(DOWNLOAD
-            ${RGL_SRC_ROOT_URL}/include/rgl/api/core.h
-            ${DEST_API_DIR}/core.h
+                ${RGL_SRC_ROOT_URL}/include/rgl/api/core.h
+                ${DEST_API_DIR}/core.h
         )
         file(DOWNLOAD
-            ${RGL_SRC_ROOT_URL}/extensions/ros2/include/rgl/api/extensions/ros2.h
-            ${DEST_API_DIR}/extensions/ros2.h
+                ${RGL_SRC_ROOT_URL}/extensions/ros2/include/rgl/api/extensions/ros2.h
+                ${DEST_API_DIR}/extensions/ros2.h
         )
     endif ()
 

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -15,7 +15,14 @@
 set(RGL_VERSION 0.15.0)
 set(RGL_TAG v${RGL_VERSION})
 
-set(RGL_LINUX_ZIP_FILENAME_BASE Linux-x64)
+# Determine RGL binary to download based on ROS distro
+if($ENV{ROS_DISTRO} STREQUAL "humble")
+    set(RGL_LINUX_ZIP_FILENAME_BASE Linux-x64)
+elseif($ENV{ROS_DISTRO} STREQUAL "jazzy")
+    set(RGL_LINUX_ZIP_FILENAME_BASE Linux-x64-jazzy)
+else()
+    message(FATAL_ERROR "ROS not found or ROS distro not supported. Please use one of {humble, jazzy}.")
+endif()
 set(RGL_LINUX_ZIP_FILENAME ${RGL_LINUX_ZIP_FILENAME_BASE}.zip)
 
 set(RGL_LINUX_ZIP_URL https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_LINUX_ZIP_FILENAME})

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -28,7 +28,7 @@ set(RGL_LINUX_ZIP_FILENAME ${RGL_LINUX_ZIP_FILENAME_BASE}.zip)
 set(RGL_LINUX_ZIP_URL https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_LINUX_ZIP_FILENAME})
 set(RGL_SRC_ROOT_URL https://raw.githubusercontent.com/RobotecAI/RobotecGPULidar/${RGL_TAG})
 
-set(DEST_SO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/RobotecGPULidar)
+set(DEST_SO_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rdParty/RobotecGPULidar)
 set(DEST_API_DIR ${DEST_SO_DIR}/include/rgl/api)
 
 set(SO_FILENAME libRobotecGPULidar.so)
@@ -42,8 +42,9 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # (each profile would execute the file download, extraction and removal without it).
 # Note: This check does not provide a full assurance (not atomic) but is good enough
 #       since this is a Clion-specific issue.
-if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/DOWNLOAD_RGL)
-    FILE(TOUCH ${CMAKE_CURRENT_SOURCE_DIR}/DOWNLOAD_RGL)
+set(RGL_DOWNLOAD_IN_PROGRESS_FILE ${CMAKE_CURRENT_BINARY_DIR}/RGL_DOWNLOAD_IN_PROGRESS)
+if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
+    FILE(TOUCH ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
 
     # Download the RGL archive files
     file(DOWNLOAD
@@ -73,8 +74,7 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/DOWNLOAD_RGL)
 
     # Remove the unwanted byproducts
     file(REMOVE ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME})
-
-    file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/DOWNLOAD_RGL)
+    file(REMOVE ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
 else ()
     message(WARNING "Omitting the RobotecGPULidar library download. This is intended when using the Clion multi-profile"
             " project reload. This may also happen due to interruption of previous project configurations. If you have"

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -11,29 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set(RGL_VERSION 0.15.0)
 set(RGL_TAG v${RGL_VERSION})
 
-set(RGL_LINUX_ZIP_URL https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/Linux-x64.zip)
-set(RGL_SRC_ZIP_URL https://github.com/RobotecAI/RobotecGPULidar/archive/refs/tags/${RGL_TAG}.zip)
-
 set(RGL_LINUX_ZIP_FILENAME_BASE Linux-x64)
-set(RGL_SRC_ZIP_FILENAME_BASE RobotecGPULidar-${RGL_VERSION})
-
 set(RGL_LINUX_ZIP_FILENAME ${RGL_LINUX_ZIP_FILENAME_BASE}.zip)
-set(RGL_SRC_ZIP_FILENAME ${RGL_SRC_ZIP_FILENAME_BASE}.zip)
+
+set(RGL_LINUX_ZIP_URL https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_LINUX_ZIP_FILENAME})
+set(RGL_SRC_ROOT_URL https://raw.githubusercontent.com/RobotecAI/RobotecGPULidar/${RGL_TAG})
 
 set(DEST_SO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/RobotecGPULidar)
 set(DEST_API_DIR ${DEST_SO_DIR}/include/rgl/api)
-set(DEST_API_EXT_DIR ${DEST_API_DIR}/extensions)
 
 set(SO_FILENAME libRobotecGPULidar.so)
-set(API_FILENAME core.h)
-set(API_EXT_ROS_FILENAME ros2.h)
 
 # Paths relative to the .zip file root.
 set(SO_REL_PATH ${SO_FILENAME})
-set(API_REL_PATH RobotecGPULidar-${RGL_VERSION}/include/rgl/api)
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -48,41 +42,37 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/DOWNLOAD_RGL)
     file(DOWNLOAD
             ${RGL_LINUX_ZIP_URL}
             ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
-            )
+    )
 
     file(DOWNLOAD
-            ${RGL_SRC_ZIP_URL}
-            ${DEST_API_DIR}/${RGL_SRC_ZIP_FILENAME}
-            )
+            ${RGL_SRC_ROOT_URL}/include/rgl/api/core.h
+            ${DEST_API_DIR}/core.h
+    )
+
+    file(DOWNLOAD
+            ${RGL_SRC_ROOT_URL}/extensions/ros2/include/rgl/api/extensions/ros2.h
+            ${DEST_API_DIR}/extensions/ros2.h
+    )
 
     # Extract the contents of the downloaded archive files
     file(ARCHIVE_EXTRACT INPUT ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
             DESTINATION ${DEST_SO_DIR}
             PATTERNS ${SO_REL_PATH}
             VERBOSE
-            )
-
-    file(ARCHIVE_EXTRACT INPUT ${DEST_API_DIR}/${RGL_SRC_ZIP_FILENAME}
-            DESTINATION ${DEST_API_DIR}
-            PATTERNS ${API_REL_PATH}/*
-            VERBOSE
-            )
+    )
 
     # Move the extracted files to their desired locations
     file(RENAME ${DEST_SO_DIR}/${SO_REL_PATH} ${DEST_SO_DIR}/${SO_FILENAME})
-    file(COPY ${DEST_API_DIR}/${API_REL_PATH} DESTINATION ${DEST_SO_DIR}/include/rgl/)
 
     # Remove the unwanted byproducts
-    file(REMOVE_RECURSE ${DEST_API_DIR}/${RGL_SRC_ZIP_FILENAME_BASE})
-    file(REMOVE ${DEST_API_DIR}/${RGL_SRC_ZIP_FILENAME})
     file(REMOVE ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME})
 
     file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/DOWNLOAD_RGL)
 else ()
     message(WARNING "Omitting the RobotecGPULidar library download. This is intended when using the Clion multi-profile"
-    " project reload. This may also happen due to interruption of previous project configurations. If you have"
-    " any issues related to the libRobotecGPULidar.so file please make sure that the DOWNLOAD_RGL file is not"
-    " present under the Code directory."
+            " project reload. This may also happen due to interruption of previous project configurations. If you have"
+            " any issues related to the libRobotecGPULidar.so file please make sure that the DOWNLOAD_RGL file is not"
+            " present under the Code directory."
     )
 endif ()
 

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -38,9 +38,6 @@ set(DEST_API_DIR ${DEST_SO_DIR}/include/rgl/api)
 
 set(SO_FILENAME libRobotecGPULidar.so)
 
-# Paths relative to the .zip file root.
-set(SO_REL_PATH ${SO_FILENAME})
-
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # This check is performed to mitigate Clion multi-profile project reload issues
@@ -74,12 +71,9 @@ if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
         # Extract the contents of the downloaded archive files
         file(ARCHIVE_EXTRACT INPUT ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
                 DESTINATION ${DEST_SO_DIR}
-                PATTERNS ${SO_REL_PATH}
+                PATTERNS ${SO_FILENAME}
                 VERBOSE
         )
-
-        # Move the extracted files to their desired locations
-        file(RENAME ${DEST_SO_DIR}/${SO_REL_PATH} ${DEST_SO_DIR}/${SO_FILENAME})
 
         # Remove the unwanted byproducts
         file(REMOVE ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME})

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -90,7 +90,7 @@ if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
                 ${DEST_API_DIR}/core.h
         )
         file(DOWNLOAD
-                ${RGL_SRC_ROOT_URL}/extensions/ros2/include/rgl/api/extensions/ros2.h
+                ${RGL_SRC_ROOT_URL}/include/rgl/api/extensions/ros2.h
                 ${DEST_API_DIR}/extensions/ros2.h
         )
 

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -104,8 +104,7 @@ if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
 else ()
     message(WARNING "Omitting the RobotecGPULidar library download. This is intended when using the Clion multi-profile"
             " project reload. This may also happen due to interruption of previous project configurations. If you have"
-            " any issues related to the libRobotecGPULidar.so file please make sure that the DOWNLOAD_RGL file is not"
-            " present under the Code directory."
+            " any issues related to the libRobotecGPULidar.so file please clear cmake cache before next build attempt."
     )
 endif ()
 

--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -46,34 +46,41 @@ set(RGL_DOWNLOAD_IN_PROGRESS_FILE ${CMAKE_CURRENT_BINARY_DIR}/RGL_DOWNLOAD_IN_PR
 if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
     FILE(TOUCH ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
 
-    # Download the RGL archive files
-    file(DOWNLOAD
+    # Download RGL binary if not exists
+    if (NOT EXISTS ${DEST_SO_DIR}/${SO_FILENAME})
+        # Download the RGL archive files
+        file(DOWNLOAD
             ${RGL_LINUX_ZIP_URL}
             ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
-    )
+        )
 
-    file(DOWNLOAD
-            ${RGL_SRC_ROOT_URL}/include/rgl/api/core.h
-            ${DEST_API_DIR}/core.h
-    )
-
-    file(DOWNLOAD
-            ${RGL_SRC_ROOT_URL}/extensions/ros2/include/rgl/api/extensions/ros2.h
-            ${DEST_API_DIR}/extensions/ros2.h
-    )
-
-    # Extract the contents of the downloaded archive files
-    file(ARCHIVE_EXTRACT INPUT ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
+        # Extract the contents of the downloaded archive files
+        file(ARCHIVE_EXTRACT INPUT ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME}
             DESTINATION ${DEST_SO_DIR}
             PATTERNS ${SO_REL_PATH}
             VERBOSE
-    )
+        )
 
-    # Move the extracted files to their desired locations
-    file(RENAME ${DEST_SO_DIR}/${SO_REL_PATH} ${DEST_SO_DIR}/${SO_FILENAME})
+        # Move the extracted files to their desired locations
+        file(RENAME ${DEST_SO_DIR}/${SO_REL_PATH} ${DEST_SO_DIR}/${SO_FILENAME})
+
+        # Remove the unwanted byproducts
+        file(REMOVE ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME})
+    endif ()
+
+    # Download API headers if not exist
+    if (NOT EXISTS ${DEST_API_DIR}/core.h OR NOT EXISTS ${DEST_API_DIR}/extensions/ros2.h)
+        file(DOWNLOAD
+            ${RGL_SRC_ROOT_URL}/include/rgl/api/core.h
+            ${DEST_API_DIR}/core.h
+        )
+        file(DOWNLOAD
+            ${RGL_SRC_ROOT_URL}/extensions/ros2/include/rgl/api/extensions/ros2.h
+            ${DEST_API_DIR}/extensions/ros2.h
+        )
+    endif ()
 
     # Remove the unwanted byproducts
-    file(REMOVE ${DEST_SO_DIR}/${RGL_LINUX_ZIP_FILENAME})
     file(REMOVE ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
 else ()
     message(WARNING "Omitting the RobotecGPULidar library download. This is intended when using the Clion multi-profile"


### PR DESCRIPTION
This PR modifies `FindRGL.cmake` to support ROS2 Jazzy besides ROS2 Humble. It also introduced minor improvements:
- does not download RGL if metadata matches
  - makes cmake reload faster
  - enables using custom RGL binaries easier
- changes directory where RGL is downloaded (`CMAKE_BINARY_DIR` instead of `CMAKE_SOURCE_DIR`)
  - good practice is to make the source directory read-only
  - resetting cmake cache makes a true clean build of the gem (with a new RGL download)
