### PR TITLE
Add BC3 compressed texture support

### DIFF
--- a/Code/Source/Utilities/BlockCompression.cpp
+++ b/Code/Source/Utilities/BlockCompression.cpp
@@ -1,0 +1,81 @@
+/* Copyright 2024, Robotec.ai sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Utilities/BlockCompression.h>
+
+namespace RGL::Utils
+{
+    AZStd::pair<size_t, size_t> BC3Block::GetBlockIndices(uint32_t width, uint32_t x, uint32_t y)
+    {
+        return AZ::RPI::BC1Block::GetBlockIndices(width, x, y);
+    }
+
+    AZ::Color BC3Block::GetBlockColor(size_t pixelIndex) const
+    {
+        AZ::Color color = m_bc1.GetBlockColor(pixelIndex);
+        color.SetA8(GetAlpha(pixelIndex));
+        return color;
+    }
+
+    static AZ::u8 LerpU8(AZ::u8 val0, AZ::u8 val1, AZ::u8 i, AZ::u8 n)
+    {
+        return (val0 * i + val1 * (n - i)) / n;
+    }
+
+    AZ::u8 BC3Block::GetAlpha(size_t pixelIndex) const
+    {
+        AZ_Assert(pixelIndex < 16, "Unsupported pixel index for BC3: %zu", pixelIndex);
+        static constexpr AZ::u8 IndexBitShift = 16U;
+        static constexpr AZ::u8 IndexBitCount = 3U;
+
+        const AZ::u8 valueBitShift = pixelIndex * IndexBitCount + IndexBitShift;
+        const AZ::u8 index = (m_alphaData >> valueBitShift) & 0b111;
+        if (m_referenceAlpha[0] > m_referenceAlpha[1])
+        {
+            switch (index)
+            {
+            case 0:
+            case 1:
+                return m_referenceAlpha[index];
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+                return LerpU8(m_referenceAlpha[1], m_referenceAlpha[0], index - 1U, 7U);
+            }
+        }
+        else
+        {
+            switch (index)
+            {
+            case 0:
+            case 1:
+                return m_referenceAlpha[index];
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+                return LerpU8(m_referenceAlpha[1], m_referenceAlpha[0], index - 1U, 5U);
+            case 6:
+                return 0U;
+            case 7:
+                return 255U;
+            }
+        }
+
+        return 0U;
+    }
+} // namespace RGL::Utils

--- a/Code/Source/Utilities/BlockCompression.h
+++ b/Code/Source/Utilities/BlockCompression.h
@@ -14,12 +14,15 @@
  */
 
 #pragma once
-#include <AzCore/Math/Color.h>
 #include <Atom/RPI.Public/BlockCompression.h>
+#include <AzCore/Math/Color.h>
 #include <AzCore/base.h>
 
 namespace RGL::Utils
 {
+    //! Structure used for decompressing images compressed using BC3.
+    //! To learn more about BC3 compression see
+    //! https://learn.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc3.
     struct BC3Block
     {
         static AZStd::pair<size_t, size_t> GetBlockIndices(uint32_t width, uint32_t x, uint32_t y);
@@ -27,8 +30,7 @@ namespace RGL::Utils
         [[nodiscard]] AZ::Color GetBlockColor(size_t pixelIndex) const;
         [[nodiscard]] AZ::u8 GetAlpha(size_t pixelIndex) const;
 
-        union
-        {
+        union {
             AZ::u64 m_alphaData;
             struct
             {

--- a/Code/Source/Utilities/BlockCompression.h
+++ b/Code/Source/Utilities/BlockCompression.h
@@ -1,0 +1,41 @@
+/* Copyright 2024, Robotec.ai sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <AzCore/Math/Color.h>
+#include <Atom/RPI.Public/BlockCompression.h>
+#include <AzCore/base.h>
+
+namespace RGL::Utils
+{
+    struct BC3Block
+    {
+        static AZStd::pair<size_t, size_t> GetBlockIndices(uint32_t width, uint32_t x, uint32_t y);
+
+        [[nodiscard]] AZ::Color GetBlockColor(size_t pixelIndex) const;
+        [[nodiscard]] AZ::u8 GetAlpha(size_t pixelIndex) const;
+
+        union
+        {
+            AZ::u64 m_alphaData;
+            struct
+            {
+                AZ::u8 m_referenceAlpha[2];
+                AZ::u8 m_alphaIndices[6];
+            };
+        };
+        AZ::RPI::BC1Block m_bc1;
+    };
+} // namespace RGL::Utils

--- a/Code/Source/Wrappers/RglTexture.cpp
+++ b/Code/Source/Wrappers/RglTexture.cpp
@@ -166,7 +166,7 @@ namespace RGL::Wrappers
             AZ_Warning(
                 ConstructTraceWindowName(__func__).c_str(),
                 false,
-                "Image \"%s\" is of unsupported type: %s. Only BC1 and BC4 formats are currently supported. Skipping...",
+                "Image \"%s\" is of unsupported type: %s. Only BC1, BC3 and BC4 formats are currently supported. Skipping...",
                 imageAsset.ToString<AZStd::string>().c_str(),
                 ToString(imageDescriptor.m_format));
         }

--- a/Code/rgl_files.cmake
+++ b/Code/rgl_files.cmake
@@ -36,6 +36,8 @@ set(FILES
         Source/Model/ModelLibrary.h
         Source/RGLSystemComponent.cpp
         Source/RGLSystemComponent.h
+        Source/Utilities/BlockCompression.cpp
+        Source/Utilities/BlockCompression.h
         Source/Utilities/RGLUtils.cpp
         Source/Utilities/RGLUtils.h
         Source/Wrappers/RglEntity.cpp


### PR DESCRIPTION
This pr adds support for the decompression of textures (used to calculate intensity textures) that use the BC3 block compression format.
Decompression of those textures was developed with the help of [this block compression guide provided by Microsoft](https://learn.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc3).