### PR TITLE
Tag entity exclusion

### DIFF
--- a/Code/Include/RGL/RGLBus.h
+++ b/Code/Include/RGL/RGLBus.h
@@ -36,6 +36,10 @@ namespace RGL
         //! Updates scene to the RGL
         virtual void UpdateScene() = 0;
 
+        //! Forces a reevaluation of entity presence conditions.
+        //! Results of this condition reevaluation influence entity's inclusion in raycasting.
+        virtual void ReviseEntityPresence(AZ::EntityId entityId) = 0;
+
     protected:
         ~RGLRequests() = default;
     };

--- a/Code/Include/RGL/SceneConfiguration.h
+++ b/Code/Include/RGL/SceneConfiguration.h
@@ -16,6 +16,8 @@
 
 #include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 #include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
 
 namespace RGL
 {
@@ -37,6 +39,7 @@ namespace RGL
         static void Reflect(AZ::ReflectContext* context);
 
         TerrainIntensityConfiguration m_terrainIntensityConfig;
+        AZStd::vector<AZStd::string> m_excludedTagNames;
         // clang-format off
         bool m_isSkinnedMeshUpdateEnabled{ true }; //!< If set to true, all skinned meshes will be updated. Otherwise they will remain unchanged.
         // clang-format on

--- a/Code/Source/Entity/EntityTagListener.cpp
+++ b/Code/Source/Entity/EntityTagListener.cpp
@@ -1,0 +1,58 @@
+/* Copyright 2024, Robotec.ai sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <Entity/EntityTagListener.h>
+#include <RGL/RGLBus.h>
+
+namespace RGL
+{
+    EntityTagListener::EntityTagListener(AZ::EntityId entityId)
+        : m_entityId(entityId)
+    {
+        AZ::EntityBus::Handler::BusConnect(m_entityId);
+    }
+
+    EntityTagListener::~EntityTagListener()
+    {
+        AZ::EntityBus::Handler::BusDisconnect(m_entityId);
+    }
+
+    void EntityTagListener::OnEntityActivated([[maybe_unused]] const AZ::EntityId& entityId)
+    {
+        LmbrCentral::Tags entityTags;
+        LmbrCentral::TagComponentRequestBus::EventResult(entityTags, m_entityId, &LmbrCentral::TagComponentRequests::GetTags);
+
+        if (!entityTags.empty())
+        {
+            RGLInterface::Get()->ReviseEntityPresence(m_entityId);
+        }
+
+        LmbrCentral::TagComponentNotificationsBus::Handler::BusConnect(m_entityId);
+    }
+
+    void EntityTagListener::OnEntityDeactivated(const AZ::EntityId& entity_id)
+    {
+        LmbrCentral::TagComponentNotificationsBus::Handler::BusDisconnect(m_entityId);
+    }
+
+    void EntityTagListener::OnTagAdded(const LmbrCentral::Tag& crc32)
+    {
+        RGLInterface::Get()->ReviseEntityPresence(m_entityId);
+    }
+
+    void EntityTagListener::OnTagRemoved(const LmbrCentral::Tag& crc32)
+    {
+        RGLInterface::Get()->ReviseEntityPresence(m_entityId);
+    }
+} // namespace RGL

--- a/Code/Source/Entity/EntityTagListener.h
+++ b/Code/Source/Entity/EntityTagListener.h
@@ -1,0 +1,40 @@
+/* Copyright 2024, Robotec.ai sp. z o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <AzCore/Component/EntityBus.h>
+#include <LmbrCentral/Scripting/TagComponentBus.h>
+
+namespace RGL
+{
+    class EntityTagListener
+        : AZ::EntityBus::Handler
+        , LmbrCentral::TagComponentNotificationsBus::Handler
+    {
+    public:
+        EntityTagListener(AZ::EntityId entityId);
+        ~EntityTagListener();
+
+        void OnEntityActivated(const AZ::EntityId&) override;
+        void OnEntityDeactivated(const AZ::EntityId&) override;
+
+        // TagComponentNotificationsBus overrides
+        void OnTagAdded(const LmbrCentral::Tag&) override;
+        void OnTagRemoved(const LmbrCentral::Tag&) override;
+
+    private:
+        AZ::EntityId m_entityId;
+    };
+} // namespace RGL

--- a/Code/Source/RGLSystemComponent.cpp
+++ b/Code/Source/RGLSystemComponent.cpp
@@ -145,15 +145,13 @@ namespace RGL
             return false;
         }
 
-        for (const auto tag : excludedTags)
-        {
-            if (entityTags.contains(tag))
+        return AZStd::any_of(
+            excludedTags.cbegin(),
+            excludedTags.cend(),
+            [&entityTags](const auto& tag)
             {
-                return true;
-            }
-        }
-
-        return false;
+                return entityTags.contains(tag);
+            });
     }
 
     void RGLSystemComponent::OnEntityContextCreateEntity(AZ::Entity& entity)

--- a/Code/Source/RGLSystemComponent.cpp
+++ b/Code/Source/RGLSystemComponent.cpp
@@ -161,7 +161,7 @@ namespace RGL
             return;
         }
 
-        m_entityTagListeners.emplace_back(entity.GetId());
+        m_entityTagListeners.emplace(entity.GetId(), entity.GetId());
 
         if (m_activeLidarCount < 1U || ShouldEntityBeExcluded(entity.GetId()))
         {
@@ -176,6 +176,7 @@ namespace RGL
     {
         m_unprocessedEntities.erase(id);
         m_entityManagers.erase(id);
+        m_entityTagListeners.erase(id);
     }
 
     void RGLSystemComponent::OnEntityContextReset()

--- a/Code/Source/RGLSystemComponent.cpp
+++ b/Code/Source/RGLSystemComponent.cpp
@@ -87,6 +87,7 @@ namespace RGL
 
         AzFramework::EntityContextEventBus::Handler::BusConnect(gameEntityContextId);
         LidarSystemNotificationBus::Handler::BusConnect();
+        AZ::TickBus::Handler::BusConnect();
 
         m_rglLidarSystem.Activate();
     }
@@ -94,6 +95,7 @@ namespace RGL
     void RGLSystemComponent::Deactivate()
     {
         m_rglLidarSystem.Deactivate();
+        AZ::TickBus::Handler::BusDisconnect();
         LidarSystemNotificationBus::Handler::BusDisconnect();
         AzFramework::EntityContextEventBus::Handler::BusDisconnect();
 
@@ -113,6 +115,18 @@ namespace RGL
     void RGLSystemComponent::SetSceneConfiguration(const SceneConfiguration& config)
     {
         m_sceneConfig = config;
+
+        m_excludedTags.resize(config.m_excludedTagNames.size());
+        AZStd::transform(
+            config.m_excludedTagNames.begin(),
+            config.m_excludedTagNames.end(),
+            m_excludedTags.begin(),
+            [](const AZStd::string& tagName) -> LmbrCentral::Tag
+            {
+                return LmbrCentral::Tag(tagName);
+            });
+        UpdateTagExcludedEntities();
+
         RGLNotificationBus::Broadcast(&RGLNotifications::OnSceneConfigurationSet, config);
     }
 
@@ -121,14 +135,37 @@ namespace RGL
         return m_sceneConfig;
     }
 
+    static bool HasExcludedTag(AZ::EntityId entityId, const AZStd::vector<LmbrCentral::Tag>& excludedTags)
+    {
+        LmbrCentral::Tags entityTags;
+        LmbrCentral::TagComponentRequestBus::EventResult(entityTags, entityId, &LmbrCentral::TagComponentRequests::GetTags);
+
+        if (entityTags.empty())
+        {
+            return false;
+        }
+
+        for (const auto tag : excludedTags)
+        {
+            if (entityTags.contains(tag))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void RGLSystemComponent::OnEntityContextCreateEntity(AZ::Entity& entity)
     {
-        if (m_excludedEntities.contains(entity.GetId()))
+        if (!HasVisuals(entity))
         {
             return;
         }
 
-        if (m_activeLidarCount < 1U)
+        m_entityTagListeners.emplace_back(entity.GetId());
+
+        if (m_activeLidarCount < 1U || ShouldEntityBeExcluded(entity.GetId()))
         {
             m_unprocessedEntities.emplace(entity.GetId());
             return;
@@ -163,6 +200,12 @@ namespace RGL
         RGLNotificationBus::Broadcast(&RGLNotifications::OnAnyLidarExists);
         for (auto entityIdIt = m_unprocessedEntities.begin(); entityIdIt != m_unprocessedEntities.end();)
         {
+            if (ShouldEntityBeExcluded(*entityIdIt))
+            {
+                ++entityIdIt;
+                continue;
+            }
+
             AZ::Entity* entity = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, *entityIdIt);
             AZ_Assert(entity, "Failed to find entity with provided id!");
@@ -189,6 +232,26 @@ namespace RGL
         m_modelLibrary.Clear();
     }
 
+    void RGLSystemComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
+    {
+        for (auto entityId : m_managersToBeRemoved)
+        {
+            m_entityManagers.erase(entityId);
+            m_unprocessedEntities.insert(entityId);
+        }
+        m_managersToBeRemoved.clear();
+    }
+
+    bool RGLSystemComponent::HasVisuals(const AZ::Entity& entity)
+    {
+        return entity.FindComponent<EMotionFX::Integration::ActorComponent>() || entity.FindComponent(AZ::Render::MeshComponentTypeId);
+    }
+
+    bool RGLSystemComponent::ShouldEntityBeExcluded(AZ::EntityId entityId) const
+    {
+        return m_excludedEntities.contains(entityId) || HasExcludedTag(entityId, m_excludedTags);
+    }
+
     void RGLSystemComponent::ProcessEntity(const AZ::Entity& entity)
     {
         AZStd::unique_ptr<EntityManager> entityManager;
@@ -209,6 +272,27 @@ namespace RGL
         AZ_Error(__func__, inserted, "Object with provided entityId already exists.");
     }
 
+    void RGLSystemComponent::UpdateTagExcludedEntities()
+    {
+        if (m_excludedTags.empty())
+        {
+            return;
+        }
+
+        for (auto entityManagerIt = m_entityManagers.begin(); entityManagerIt != m_entityManagers.end();)
+        {
+            if (HasExcludedTag(entityManagerIt->first, m_excludedTags))
+            {
+                m_unprocessedEntities.insert(entityManagerIt->first);
+                entityManagerIt = m_entityManagers.erase(entityManagerIt);
+            }
+            else
+            {
+                ++entityManagerIt;
+            }
+        }
+    }
+
     void RGLSystemComponent::UpdateScene()
     {
         AZ::ScriptTimePoint currentTime;
@@ -223,6 +307,35 @@ namespace RGL
         for (auto&& [entityId, entityManager] : m_entityManagers)
         {
             entityManager->Update();
+        }
+    }
+
+    void RGLSystemComponent::ReviseEntityPresence(AZ::EntityId entityId)
+    {
+        if (m_activeLidarCount < 1U)
+        {
+            return; // No lidars exist. Every entity should stay as unprocessed until they do.
+        }
+
+        if (m_excludedEntities.contains(entityId))
+        {
+            return; // Already not included.
+        }
+
+        if (HasExcludedTag(entityId, m_excludedTags))
+        {
+            if (m_entityManagers.contains(entityId))
+            {
+                m_managersToBeRemoved.push_back(entityId);
+            }
+        }
+        else if (const auto it = m_unprocessedEntities.find(entityId); it != m_unprocessedEntities.end())
+        {
+            m_unprocessedEntities.erase(it);
+            AZ::Entity* entity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
+            AZ_Assert(entity, "Failed to find entity with provided id!");
+            ProcessEntity(*entity);
         }
     }
 } // namespace RGL

--- a/Code/Source/RGLSystemComponent.h
+++ b/Code/Source/RGLSystemComponent.h
@@ -86,9 +86,9 @@ namespace RGL
 
         AZStd::set<AZ::EntityId> m_excludedEntities;
         AZStd::set<AZ::EntityId> m_unprocessedEntities;
+        AZStd::unordered_map<AZ::EntityId, EntityTagListener> m_entityTagListeners;
         AZStd::vector<AZ::EntityId> m_managersToBeRemoved;
         AZStd::unordered_map<AZ::EntityId, AZStd::unique_ptr<EntityManager>> m_entityManagers;
-        AZStd::vector<EntityTagListener> m_entityTagListeners;
 
         AZStd::vector<LmbrCentral::Tag> m_excludedTags;
 

--- a/Code/Source/SceneConfiguration.cpp
+++ b/Code/Source/SceneConfiguration.cpp
@@ -61,6 +61,7 @@ namespace RGL
             serializeContext->Class<SceneConfiguration>()
                 ->Version(0)
                 ->Field("TerrainIntensityConfig", &SceneConfiguration::m_terrainIntensityConfig)
+                ->Field("excludedTagNames", &SceneConfiguration::m_excludedTagNames)
                 ->Field("SkinnedMeshUpdate", &SceneConfiguration::m_isSkinnedMeshUpdateEnabled);
 
             if (auto* editContext = serializeContext->GetEditContext())
@@ -68,6 +69,11 @@ namespace RGL
                 editContext->Class<SceneConfiguration>("RGL Scene Configuration", "")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &SceneConfiguration::m_terrainIntensityConfig, "Terrain Intensity Configuration", "")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SceneConfiguration::m_excludedTagNames,
+                        "Raycast excluded Tag names",
+                        "Entities tagged with names present in this list will not be included in raycasting.")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &SceneConfiguration::m_isSkinnedMeshUpdateEnabled,

--- a/Code/rgl_files.cmake
+++ b/Code/rgl_files.cmake
@@ -18,6 +18,8 @@ set(FILES
         Source/Entity/MeshEntityManager.h
         Source/Entity/EntityManager.cpp
         Source/Entity/EntityManager.h
+        Source/Entity/EntityTagListener.cpp
+        Source/Entity/EntityTagListener.h
         Source/Entity/MaterialEntityManager.cpp
         Source/Entity/MaterialEntityManager.h
         Source/Entity/Terrain/TerrainData.cpp


### PR DESCRIPTION
This pr adds a new way to exclude entities from raycasting using the Tag component.
 - excluded tag names were added as a field to the scene configuration component.
 - added a way to dynamically handle entity exclusion from raycasting based on their tags.  
 
 To exclude an entity from raycasting tag it using the tag component and include the tag name in the scene configuration componet.