### PR TITLE
Ensure Entity Manager Ebus disconnection on destruction

### DIFF
--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -39,6 +39,16 @@ namespace RGL
 
     ActorEntityManager::~ActorEntityManager()
     {
+        if (AZ::Render::MaterialComponentNotificationBus::Handler::BusIsConnected())
+        {
+            AZ::Render::MaterialComponentNotificationBus::Handler::BusDisconnect();
+        }
+
+        if (EMotionFX::Integration::ActorComponentNotificationBus::Handler::BusIsConnected())
+        {
+            EMotionFX::Integration::ActorComponentNotificationBus::Handler::BusDisconnect();
+        }
+
         AZ::EntityBus::Handler::BusDisconnect();
     }
 

--- a/Code/Source/Entity/MeshEntityManager.cpp
+++ b/Code/Source/Entity/MeshEntityManager.cpp
@@ -31,6 +31,16 @@ namespace RGL
 
     MeshEntityManager::~MeshEntityManager()
     {
+        if (AZ::Render::MaterialComponentNotificationBus::Handler::BusIsConnected())
+        {
+            AZ::Render::MaterialComponentNotificationBus::Handler::BusDisconnect();
+        }
+
+        if (AZ::Render::MeshComponentNotificationBus::Handler::BusIsConnected())
+        {
+            AZ::Render::MeshComponentNotificationBus::Handler::BusDisconnect();
+        }
+
         AZ::EntityBus::Handler::BusDisconnect();
     }
 


### PR DESCRIPTION
This PR fixes Ebus connection errors for Entity managers by making sure handlers disconnect prior to destruction.