### PR TITLE
Fix required ROS2 gem version in main

### DIFF
--- a/gem.json
+++ b/gem.json
@@ -22,7 +22,8 @@
     "requirements": "Requires a CUDA-capable GPU with the nvidia drivers specified in the README.md file of the RGL gem github repository.",
     "documentation_url": "",
     "dependencies": [
-        "ROS2<=3.1.0"
+        "ROS2>=3.1.0",
+        "ROS2<3.3.0"
     ],
     "restricted": "RGL"
 }


### PR DESCRIPTION
It is possible to use RGL gem with few particular commits of the `development` branch with O3DE 2409.x, but only with ROS2 Humble and it was never released into `main`. The current `development` HEAD requires changed API of ROS2 Gem (in the `development` branch of O3DE), while the current of the `main` branch builds only with O3DE 2310.x, leaving O3DE 2409.x out of the scope. 

This PR changes the ROS2 gem version requirement to serve both 2310.x and 2409.x, as the Lidar API did not change between the versions. This way the same HEAD of the `main` branch will work correctly with both ROS 2 Jazzy and ROS 2 Humble, 2409.x or 2310.x.