### PR TITLE
Fix required ROS2 gem version

### DIFF
--- a/gem.json
+++ b/gem.json
@@ -22,7 +22,7 @@
     "requirements": "Requires a CUDA-capable GPU with the nvidia drivers specified in the README.md file of the RGL gem github repository.",
     "documentation_url": "",
     "dependencies": [
-        "ROS2>=3.2.0",
+        "ROS2>=3.3.0",
         "LmbrCentral"
     ],
     "restricted": "RGL"


### PR DESCRIPTION
The changes in #49 and later are only available in o3de-extras `development` branch, ROS2 Gem 3.3.0. This was set as the requirements for this gem to ensure smooth build process.