### PR TITLE
Insert missing Scene Configuration component descriptor

### DIFF
--- a/Code/Source/RGLModuleInterface.h
+++ b/Code/Source/RGLModuleInterface.h
@@ -18,6 +18,7 @@
 #include <AzCore/Module/Module.h>
 #include <Entity/Terrain/TerrainEntityManagerSystemComponent.h>
 #include <RGLSystemComponent.h>
+#include <SceneConfigurationComponent.h>
 
 namespace RGL
 {
@@ -38,6 +39,7 @@ namespace RGL
                 {
                     RGLSystemComponent::CreateDescriptor(),
                     TerrainEntityManagerSystemComponent::CreateDescriptor(),
+                    SceneConfigurationComponent::CreateDescriptor(),
                 });
         }
 


### PR DESCRIPTION
Fixes https://github.com/RobotecAI/o3de-rgl-gem/issues/69.