### PR TITLE
Reflectivity support

### DIFF
--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set(RGL_VERSION 0.19.0)
+set(RGL_VERSION 0.20.0)
 set(RGL_TAG v${RGL_VERSION})
 
 # Metadata files used to determine if RGL download is required
 set(RGL_VERSION_METADATA_FILE ${CMAKE_CURRENT_BINARY_DIR}/RGL_VERSION)
-set(ROS_DISTRO_METADATA_FILE ${CMAKE_CURRENT_BINARY_DIR}/ROS_DISTRO)
 
 set(ROS_DISTRO $ENV{ROS_DISTRO})
 set(RGL_LINUX_ZIP_FILENAME_BASE RGL-core-linux-x64)
@@ -42,7 +41,6 @@ if (NOT EXISTS ${RGL_DOWNLOAD_IN_PROGRESS_FILE})
 
     # Read metadata
     set(RGL_VERSION_METADATA " ")
-    set(ROS_DISTRO_METADATA " ")
     if (EXISTS ${RGL_VERSION_METADATA_FILE})
         file(READ ${RGL_VERSION_METADATA_FILE} RGL_VERSION_METADATA)
     endif ()

--- a/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Code/Source/Lidar/LidarRaycaster.cpp
@@ -118,6 +118,11 @@ namespace RGL
             m_rglRaycastResults.m_fields.push_back(RGL_FIELD_RING_ID_U16);
         }
 
+        if (ROS2::IsFlagEnabled(ROS2::RaycastResultFlags::Reflectivity, flags))
+        {
+            m_rglRaycastResults.m_fields.push_back(RGL_FIELD_REFLECTIVITY_F32);
+        }
+
         m_graph.ConfigureFieldNodes(m_rglRaycastResults.m_fields.data(), m_rglRaycastResults.m_fields.size());
         m_graph.SetIsCompactEnabled(!m_returnNonHits);
     }
@@ -188,6 +193,11 @@ namespace RGL
         if (auto ring = raycastResults.GetFieldSpan<ROS2::RaycastResultFlags::Ring>(); ring.has_value())
         {
             AZStd::copy(m_rglRaycastResults.m_ringId.begin(), m_rglRaycastResults.m_ringId.end(), ring.value().begin());
+        }
+
+        if (auto reflectivity = raycastResults.GetFieldSpan<ROS2::RaycastResultFlags::Reflectivity>(); reflectivity.has_value())
+        {
+            AZStd::copy(m_rglRaycastResults.m_reflectivity.begin(), m_rglRaycastResults.m_reflectivity.end(), reflectivity.value().begin());
         }
 
         return AZ::Success(m_raycastResults.value());
@@ -303,6 +313,18 @@ namespace RGL
                 resultsSize = rglResults.m_ringId.size();
             }
             else if (resultsSize != rglResults.m_ringId.size())
+            {
+                return AZStd::nullopt;
+            }
+        }
+
+        if (results.IsFieldPresent<ROS2::RaycastResultFlags::Reflectivity>())
+        {
+            if (!resultsSize.has_value())
+            {
+                resultsSize = rglResults.m_reflectivity.size();
+            }
+            else if (resultsSize != rglResults.m_reflectivity.size())
             {
                 return AZStd::nullopt;
             }

--- a/Code/Source/Lidar/LidarSystem.cpp
+++ b/Code/Source/Lidar/LidarSystem.cpp
@@ -30,7 +30,7 @@ namespace RGL
 
         using Features = ROS2::LidarSystemFeatures;
         static constexpr auto SupportedFeatures = aznumeric_cast<Features>(
-            Features::EntityExclusion | Features::Noise | Features::Intensity | Features::Segmentation | Features::RingIds);
+            Features::EntityExclusion | Features::Noise | Features::Intensity | Features::Segmentation | Features::RingIds | Features::Reflectivity);
 
         ROS2::LidarSystemRequestBus::Handler::BusConnect(AZ_CRC(name));
 

--- a/Code/Source/Lidar/PipelineGraph.cpp
+++ b/Code/Source/Lidar/PipelineGraph.cpp
@@ -155,6 +155,9 @@ namespace RGL
             case RGL_FIELD_RING_ID_U16:
                 success = success && GetResult(results.m_ringId, RGL_FIELD_RING_ID_U16);
                 break;
+            case RGL_FIELD_REFLECTIVITY_F32:
+                success = success && GetResult(results.m_reflectivity, RGL_FIELD_REFLECTIVITY_F32);
+                break;
             default:
                 success = false;
                 AZ_Assert(false, AZStd::string::format("Invalid result field type with RGL id %i!", field).c_str());

--- a/Code/Source/Lidar/PipelineGraph.h
+++ b/Code/Source/Lidar/PipelineGraph.h
@@ -40,6 +40,7 @@ namespace RGL
             AZStd::vector<int32_t> m_packedRglEntityId;
             AZStd::vector<int32_t> m_isHit;
             AZStd::vector<uint16_t> m_ringId;
+            AZStd::vector<float> m_reflectivity;
         };
 
         struct Nodes


### PR DESCRIPTION
This pr introduces support for the reflectivity field. It is related to the https://github.com/RobotecAI/o3de-extras/pull/63.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for reflectivity data in Lidar raycasting
	- Enhanced Lidar system capabilities with new reflectivity feature

- **Dependency Updates**
	- Updated RGL library version from 0.19.0 to 0.20.0

- **Technical Improvements**
	- Expanded raycast result processing to include reflectivity information
	- Updated pipeline graph to handle new reflectivity field

<!-- end of auto-generated comment: release notes by coderabbit.ai -->