### PR TITLE
Fix lidar min/max and dense/compact setups

### DIFF
--- a/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Code/Source/Lidar/LidarRaycaster.cpp
@@ -224,13 +224,19 @@ namespace RGL
         float minRangeNonHitValue = -AZStd::numeric_limits<float>::infinity();
         float maxRangeNonHitValue = AZStd::numeric_limits<float>::infinity();
 
-        if (m_returnNonHits && m_range.has_value())
+        if (m_returnNonHits && m_nonHitRange.has_value())
         {
-            minRangeNonHitValue = m_range.value().m_min;
-            maxRangeNonHitValue = m_range.value().m_max;
+            minRangeNonHitValue = m_nonHitRange.value().m_min;
+            maxRangeNonHitValue = m_nonHitRange.value().m_max;
         }
 
         m_graph.ConfigureRaytraceNodeNonHits(minRangeNonHitValue, maxRangeNonHitValue);
+    }
+
+    void LidarRaycaster::ConfigureNonHitValues(AZStd::optional<ROS2::RayRange> range)
+    {
+        m_nonHitRange = range;
+        UpdateNonHitValues();
     }
 
     void LidarRaycaster::ConfigureNonHitReturn(bool returnNonHits)

--- a/Code/Source/Lidar/LidarRaycaster.h
+++ b/Code/Source/Lidar/LidarRaycaster.h
@@ -48,13 +48,15 @@ namespace RGL
             [[maybe_unused]] float distanceNoiseStdDevBase,
             [[maybe_unused]] float distanceNoiseStdDevRisePerMeter) override;
         void ExcludeEntities(const AZStd::vector<AZ::EntityId>& excludedEntities) override;
-        void UpdateNonHitValues();
+        void ConfigureNonHitValues(AZStd::optional<ROS2::RayRange> range) override;
         void ConfigureNonHitReturn(bool returnNonHits) override;
         void ConfigureRayRingIds(const AZStd::vector<AZ::s32>& ringIds) override;
 
     private:
         AZ::Uuid m_uuid;
 
+        void UpdateNonHitValues();
+        AZStd::optional<ROS2::RayRange> m_nonHitRange{};
         bool m_returnNonHits{ false }; //!< Determines whether max range point addition is enabled.
 
         AZStd::optional<ROS2::RayRange> m_range{};


### PR DESCRIPTION
This PR adds the support for `ConfigureNonHitValues` interface, which was needed to fully support changes from https://github.com/RobotecAI/o3de-extras/pull/65 

It was tested together with https://github.com/RobotecAI/o3de-extras/pull/65 