### PR TITLE
Add actor data clearing upon entity deactivation

### DIFF
--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -79,15 +79,13 @@ namespace RGL
     void ActorEntityManager::OnActorInstanceDestroyed(EMotionFX::ActorInstance* actorInstance)
     {
         AZ::Render::MaterialComponentNotificationBus::Handler::BusDisconnect();
-        ResetMaterialsMapping();
-        m_entities.clear();
-        m_rglSubMeshes.clear();
-        m_emotionFxMesh = nullptr;
+        ClearActorData();
     }
 
     void ActorEntityManager::OnEntityDeactivated(const AZ::EntityId& entityId)
     {
         AZ::Render::MaterialComponentNotificationBus::Handler::BusDisconnect();
+        ClearActorData();
         EMotionFX::Integration::ActorComponentNotificationBus::Handler::BusDisconnect();
         MaterialEntityManager::OnEntityDeactivated(entityId);
     }
@@ -211,8 +209,7 @@ namespace RGL
             const size_t indexBase = subMesh->GetStartIndex() / 3U; // RGL uses index triples.
             const size_t indexCount = subMesh->GetNumIndices() / 3U;
 
-            auto rglMesh =
-                Wrappers::RglMesh(vertexPositions.data() + vertexBase, vertexCount, indices.data() + indexBase, indexCount);
+            auto rglMesh = Wrappers::RglMesh(vertexPositions.data() + vertexBase, vertexCount, indices.data() + indexBase, indexCount);
 
             if (rglMesh.IsValid())
             {
@@ -263,5 +260,13 @@ namespace RGL
         }
 
         return true;
+    }
+
+    void ActorEntityManager::ClearActorData()
+    {
+        ResetMaterialsMapping();
+        m_entities.clear();
+        m_rglSubMeshes.clear();
+        m_emotionFxMesh = nullptr;
     }
 } // namespace RGL

--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -174,7 +174,7 @@ namespace RGL
 
     void ActorEntityManager::UpdateMeshVertices()
     {
-        if (!m_emotionFxMesh)
+        if (!m_emotionFxMesh || !m_actorInstance)
         {
             return;
         }
@@ -268,5 +268,6 @@ namespace RGL
         m_entities.clear();
         m_rglSubMeshes.clear();
         m_emotionFxMesh = nullptr;
+        m_actorInstance = nullptr;
     }
 } // namespace RGL

--- a/Code/Source/Entity/ActorEntityManager.cpp
+++ b/Code/Source/Entity/ActorEntityManager.cpp
@@ -76,7 +76,7 @@ namespace RGL
         }
     }
 
-    void ActorEntityManager::OnActorInstanceDestroyed(EMotionFX::ActorInstance* actorInstance)
+    void ActorEntityManager::OnActorInstanceDestroyed([[maybe_unused]] EMotionFX::ActorInstance* actorInstance)
     {
         AZ::Render::MaterialComponentNotificationBus::Handler::BusDisconnect();
         ClearActorData();

--- a/Code/Source/Entity/ActorEntityManager.h
+++ b/Code/Source/Entity/ActorEntityManager.h
@@ -60,6 +60,7 @@ namespace RGL
         void UpdateMeshVertices();
         //! Loads mesh's vertex position data into the m_tempVertexPositions buffer.
         bool ProcessEfxMesh(const EMotionFX::Mesh& mesh);
+        void ClearActorData();
 
         EMotionFX::ActorInstance* m_actorInstance = nullptr;
         // We do not use the ModelLibrary since the actor mesh is


### PR DESCRIPTION
Sometimes the Actor Entity update may be triggered before destruction but after deactivation. Additionally the `OnActorInstanceDestroyed` may not be called before the deactivation of the entity. Due to this an additional actor entity manager cleanup was added to the `OnEntityDeactivated` handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Introduced a new method `ClearActorData()` to centralize actor data cleanup logic.
	- Improved code organization by consolidating reset and clearing operations in a single method.
	- Enhanced control flow in mesh updates by validating both entities before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->