### PR TITLE
Fix linking with rclcpp

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -37,6 +37,8 @@ ly_add_target(
             Gem::EMotionFX.Static
 )
 
+target_depends_on_ros2_packages(RGL.Static rclcpp)
+
 ly_target_link_libraries(RGL.Static PUBLIC ${RGL_SO_DIR})
 
 ly_add_target_files(

--- a/gem.json
+++ b/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "RGL",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "platforms": [
         "Linux"
     ],


### PR DESCRIPTION
There were some changes in ROS 2 linking and dependency resolving, so we need to explicitly add the ROS 2 dependency for RGL.Static.