### PR TITLE
Update RGL (native library) version (v0.21.0)

### DIFF
--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set(RGL_VERSION 0.19.0)
+set(RGL_VERSION 0.21.0)
 set(RGL_TAG v${RGL_VERSION})
 
 # Metadata files used to determine if RGL download is required

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also choose one of the presets provided by the ROS2 Gem to create a LiDA
 
 - [
   **Runtime requirements** of the Robotec GPU Lidar.
-  ](https://github.com/RobotecAI/RobotecGPULidar#runtime-requirements)
+  ](https://github.com/RobotecAI/RobotecGPULidar/tree/v0.21.0#runtime-requirements)
 - Any O3DE project with the [O3DE ROS2 Gem](https://github.com/o3de/o3de-extras/tree/development/Gems/ROS2) enabled.
 - The following ROS 2 packages installed on your system:
     - `cyclonedds`,

--- a/gem.json
+++ b/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "RGL",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "platforms": [
         "Linux"
     ],


### PR DESCRIPTION
RGL binaries updated from `v0.19.0` to `v0.21.0`

New RGL binaries now require a newer minimum GPU architecture (GeForce RTX 2000 series or newer), as support for deprecated CUDA architectures has been removed. This change was necessary to fix runtime errors that occurred when binaries built for deprecated architectures were executed with the latest NVIDIA drivers.