### PR TITLE
Cherry-pick RGL update from 2505.x

### DIFF
--- a/Code/FindRGL.cmake
+++ b/Code/FindRGL.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set(RGL_VERSION 0.19.0)
+set(RGL_VERSION 0.21.0)
 set(RGL_TAG v${RGL_VERSION})
 
 # Metadata files used to determine if RGL download is required

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the **RUNTIME** requirements.*
 
   The latest versions of the Gem (`development` branch) are expected to work with the latest versions of O3DE and ROS2 Gem (Release 2510.x and newer), but they have not been fully tested yet.
 
-   ***Note:*** *This table describes build combinations that are guaranteed to work. There may exist other working build combinations.*
+   **_Note:_** _This table describes build combinations that are guaranteed to work. There may exist other working build combinations._
 
 3. **Register the Gem.** \
    You can either register the Gem through the Command Line Interface or the O3DE Project Manager:
@@ -100,7 +100,7 @@ the **RUNTIME** requirements.*
         ./scripts/o3de.sh register --gem-path <gem-path>
         ```
     - **Project Manager** \
-      Open the Project Manager. Select **Gems -> Add Existing Gem**. Locate the gem's directory and select **Choose**.
+      Open the Project Manager. Select **Gems -> Add Existing Gem**. Locate the Gem's directory and select **Choose**.
 
 4. **Enable the Gem in your project.** \
    Once again you can either enable it through the Command Line Interface or the O3DE Project Manager:
@@ -108,7 +108,7 @@ the **RUNTIME** requirements.*
    ***Note:*** *Please, make sure to enable the ROS2 Gem first.*
 
     - **CLI** \
-      In your local o3de engine directory you can enable the gem for your project (*project-path*).
+      In your local O3DE engine directory you can enable the Gem for your project (*project-path*).
         ```bash
         ./scripts/o3de.sh enable-gem -gn RGL -pp <project-path>
         ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also choose one of the presets provided by the ROS2 Gem to create a LiDA
 
 - [
   **Runtime requirements** of the Robotec GPU Lidar.
-  ](https://github.com/RobotecAI/RobotecGPULidar#runtime-requirements)
+  ](https://github.com/RobotecAI/RobotecGPULidar/tree/v0.21.0#runtime-requirements)
 - Any O3DE project with the [O3DE ROS2 Gem](https://github.com/o3de/o3de-extras/tree/development/Gems/ROS2) enabled.
 - The following ROS 2 packages installed on your system:
     - `cyclonedds`,

--- a/gem.json
+++ b/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "RGL",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "platforms": [
         "Linux"
     ],


### PR DESCRIPTION
Cherry-pick commit with RGL update from the stable branch for O3DE 2505.x into `development`, which can be used with O3DE 2510 and future 2605.
Additionally, the README was synchronized after the last changes in the `o3de-2505` branch.

The patch version of the Gem was bumped (1.3.0 -> 1.3.1).

Edit: tested on O3DE 2510 on Ubuntu 2204 with Humble.